### PR TITLE
[Add] Color Asset 추가 및 익스텐션 적용

### DIFF
--- a/DaangnMarket-iOS/DaangnMarket-iOS.xcodeproj/project.pbxproj
+++ b/DaangnMarket-iOS/DaangnMarket-iOS.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		EBB2604A2832337D001416D8 /* AroundVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB260492832337D001416D8 /* AroundVC.swift */; };
 		EBB2604C28323386001416D8 /* ChatVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB2604B28323386001416D8 /* ChatVC.swift */; };
 		EBB2604E28323393001416D8 /* MyPageVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB2604D28323393001416D8 /* MyPageVC.swift */; };
+		EBB260502832606B001416D8 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EBB2604F2832606B001416D8 /* Colors.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -148,6 +149,7 @@
 		EBB260492832337D001416D8 /* AroundVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AroundVC.swift; sourceTree = "<group>"; };
 		EBB2604B28323386001416D8 /* ChatVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatVC.swift; sourceTree = "<group>"; };
 		EBB2604D28323393001416D8 /* MyPageVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageVC.swift; sourceTree = "<group>"; };
+		EBB2604F2832606B001416D8 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -335,6 +337,7 @@
 			isa = PBXGroup;
 			children = (
 				EBB25F7D28311103001416D8 /* Assets.xcassets */,
+				EBB2604F2832606B001416D8 /* Colors.xcassets */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -662,6 +665,7 @@
 				EBB2603F28322C21001416D8 /* PostWrite.storyboard in Resources */,
 				EBB2603B28322BB1001416D8 /* PostList.storyboard in Resources */,
 				EBB25F8128311103001416D8 /* LaunchScreen.storyboard in Resources */,
+				EBB260502832606B001416D8 /* Colors.xcassets in Resources */,
 				EBB260352832228D001416D8 /* PostDetail.storyboard in Resources */,
 				EBB25F7E28311103001416D8 /* Assets.xcassets in Resources */,
 			);

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Extension/Design/UIColor+.swift
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Extension/Design/UIColor+.swift
@@ -9,91 +9,47 @@ import UIKit
 
 extension UIColor {
     
-    @nonobjc class var white: UIColor {
+    @nonobjc class var carrotWhite: UIColor {
         return UIColor(white: 1.0, alpha: 1.0)
     }
     
-    @nonobjc class var nadoBlack: UIColor {
-        return UIColor(red: 0.0, green: 29.0 / 255.0, blue: 25.0 / 255.0, alpha: 1.0)
+    @nonobjc class var carrotBlack: UIColor {
+        return UIColor(red: 27.0 / 255.0, green: 26.0 / 255.0, blue: 31.0 / 255.0, alpha: 1.0)
     }
     
-    @nonobjc class var mainBlack: UIColor {
-        return UIColor(red: 0.0, green: 28.0 / 255.0, blue: 24.0 / 255.0, alpha: 1.0)
+    @nonobjc class var carrotButtonOrange: UIColor {
+        return UIColor(red: 254.0 / 126.0, green: 53.0 / 255.0, blue: 1.0 / 255.0, alpha: 1.0)
     }
     
-    @nonobjc class var gray0: UIColor {
-        return UIColor(red: 246.0 / 255.0, green: 246.0 / 255.0, blue: 249.0 / 255.0, alpha: 1.0)
+    @nonobjc class var carrotTextOrange: UIColor {
+        return UIColor(red: 241.0 / 255.0, green: 132.0 / 255.0, blue: 79.0 / 255.0, alpha: 1.0)
     }
     
-    @nonobjc class var gray1: UIColor {
-        return UIColor(red: 232.0 / 255.0, green: 232.0 / 255.0, blue: 235.0 / 255.0, alpha: 1.0)
+    @nonobjc class var carrotBlue: UIColor {
+        return UIColor(red: 21.0 / 255.0, green: 105.0 / 255.0, blue: 184.0 / 255.0, alpha: 1.0)
     }
     
-    @nonobjc class var gray2: UIColor {
-        return UIColor(red: 192.0 / 255.0, green: 192.0 / 255.0, blue: 203.0 / 255.0, alpha: 1.0)
+    @nonobjc class var carrotDeepGray: UIColor {
+        return UIColor(red: 49.0 / 255.0, green: 49.0 / 255.0, blue: 49.0 / 255.0, alpha: 1.0)
     }
     
-    @nonobjc class var mainDark: UIColor {
-        return UIColor(red: 5.0 / 255.0, green: 161.0 / 255.0, blue: 143.0 / 255.0, alpha: 1.0)
+    @nonobjc class var carrotDarkLightGray: UIColor {
+        return UIColor(red: 132.0 / 255.0, green: 136.0 / 255.0, blue: 146.0 / 255.0, alpha: 1.0)
     }
     
-    @nonobjc class var mainLight: UIColor {
-        return UIColor(red: 223.0 / 255.0, green: 246.0 / 255.0, blue: 244.0 / 255.0, alpha: 1.0)
+    @nonobjc class var carrotLineGray: UIColor {
+        return UIColor(red: 169.0 / 255.0, green: 169.0 / 255.0, blue: 169.0 / 255.0, alpha: 1.0)
     }
     
-    @nonobjc class var gray4: UIColor {
-        return UIColor(red: 86.0 / 255.0, green: 86.0 / 255.0, blue: 95.0 / 255.0, alpha: 1.0)
+    @nonobjc class var carrotSquareGray: UIColor {
+        return UIColor(red: 226.0 / 255.0, green: 226.0 / 255.0, blue: 228.0 / 255.0, alpha: 1.0)
     }
     
-    @nonobjc class var mainText: UIColor {
-        return UIColor(white: 60.0 / 255.0, alpha: 1.0)
+    @nonobjc class var carrotSquareLightGray: UIColor {
+        return UIColor(red: 227.0 / 255.0, green: 226.0 / 255.0, blue: 231.0 / 255.0, alpha: 1.0)
     }
     
-    @nonobjc class var gray3: UIColor {
-        return UIColor(red: 148.0 / 255.0, green: 149.0 / 255.0, blue: 158.0 / 255.0, alpha: 1.0)
-    }
-    
-    @nonobjc class var mainDefault: UIColor {
-        return UIColor(red: 0.0, green: 200.0 / 255.0, blue: 176.0 / 255.0, alpha: 1.0)
-    }
-    
-    @nonobjc class var shadowDefault: UIColor {
-        return UIColor(red: 229.0 / 255.0, green: 229.0 / 255.0, blue: 232.0 / 255.0, alpha: 1.0)
-    }
-    
-    @nonobjc class var paleGray: UIColor {
-        return UIColor(red: 251.0 / 255.0, green: 251.0 / 255.0, blue: 253.0 / 255.0, alpha: 1.0)
-    }
-    
-    @nonobjc class var red: UIColor {
-        return UIColor(red: 255.0 / 255.0, green: 76.0 / 255.0, blue: 64.0 / 255.0, alpha: 1.0)
-    }
-
-    @nonobjc class var bgGray: UIColor {
-        return UIColor(red: 248.0 / 255.0, green: 249.0 / 255.0, blue: 253.0 / 255.0, alpha: 1.0)
-    }
-    
-    @nonobjc class var scrollMint: UIColor {
-        return UIColor(red: 187.0 / 255.0, green: 242.0 / 255.0, blue: 236.0 / 255.0, alpha: 1.0)
-    }
-    
-    @nonobjc class var separatorGray: UIColor {
-        return UIColor(red: 234.0 / 255.0, green: 235.0 / 255.0, blue: 241.0 / 255.0, alpha: 1.0)
-    }
-    
-    @nonobjc class var lightMint: UIColor {
-        return UIColor(red: 169.0 / 255.0, green: 244.0 / 255.0, blue: 235.0 / 255.0, alpha: 1.0)
-    }
-    
-    @nonobjc class var chatFill: UIColor {
-        return UIColor(red: 234.0 / 255.0, green: 250.0 / 255.0, blue: 248.0 / 255.0, alpha: 1.0)
-    }
-
-    @nonobjc class var chatStroke: UIColor {
-        return UIColor(red: 208.0 / 255.0, green: 242.0 / 255.0, blue: 238.0 / 255.0, alpha: 1.0)
-    }
-    
-    @nonobjc class var mintBgColor: UIColor {
-        return UIColor(red: 239.0 / 255.0, green: 246.0 / 255.0, blue: 246.0 / 255.0, alpha: 1.0)
+    @nonobjc class var carrotLineLightGray: UIColor {
+        return UIColor(red: 240.0 / 240.0, green: 28.0 / 240.0, blue: 1.0 / 255.0, alpha: 1.0)
     }
 }

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/Contents.json
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_black.colorset/Contents.json
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_black.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.122",
+          "green" : "0.102",
+          "red" : "0.106"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.122",
+          "green" : "0.102",
+          "red" : "0.106"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_blue.colorset/Contents.json
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_blue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.651",
+          "green" : "0.380",
+          "red" : "0.094"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.651",
+          "green" : "0.380",
+          "red" : "0.094"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_button_orange.colorset/Contents.json
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_button_orange.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.208",
+          "green" : "0.494",
+          "red" : "0.996"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.208",
+          "green" : "0.494",
+          "red" : "0.996"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_darklightgray.colorset/Contents.json
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_darklightgray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.573",
+          "green" : "0.533",
+          "red" : "0.518"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.573",
+          "green" : "0.533",
+          "red" : "0.518"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_deepgray.colorset/Contents.json
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_deepgray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.192",
+          "green" : "0.192",
+          "red" : "0.192"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.192",
+          "green" : "0.192",
+          "red" : "0.192"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_linegray.colorset/Contents.json
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_linegray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.663",
+          "green" : "0.663",
+          "red" : "0.663"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.663",
+          "green" : "0.663",
+          "red" : "0.663"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_linelightgray.colorset/Contents.json
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_linelightgray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.941",
+          "green" : "0.941",
+          "red" : "0.941"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.941",
+          "green" : "0.941",
+          "red" : "0.941"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_square_gray.colorset/Contents.json
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_square_gray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.894",
+          "green" : "0.886",
+          "red" : "0.886"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.894",
+          "green" : "0.886",
+          "red" : "0.886"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_squaregray.colorset/Contents.json
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_squaregray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.906",
+          "green" : "0.886",
+          "red" : "0.890"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.906",
+          "green" : "0.886",
+          "red" : "0.890"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_text_orange.colorset/Contents.json
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_text_orange.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.208",
+          "green" : "0.494",
+          "red" : "0.996"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.208",
+          "green" : "0.494",
+          "red" : "0.996"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_white.colorset/Contents.json
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Global/Resources/Colors.xcassets/carrot_white.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#2

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
스토리보드 : Color Asset을 추가해서 스토리보드 인스펙터 에리어에서 사용할 수 있습니다.
코드 : `UIColor.carrotBlack`과 같은 식으로 코드에서도 접근 가능합니다.

## 📟 관련 이슈
- Resolved: #2 
