### PR TITLE
[Feat] #27 - Put및 Get 예시코드

### DIFF
--- a/DaangnMarket-iOS/DaangnMarket-iOS.xcodeproj/project.pbxproj
+++ b/DaangnMarket-iOS/DaangnMarket-iOS.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		8EE63065283E8F420057B61B /* PostTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE63063283E8F420057B61B /* PostTVC.swift */; };
 		8EE63066283E8F420057B61B /* PostTVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8EE63064283E8F420057B61B /* PostTVC.xib */; };
 		8EE63068283E98C10057B61B /* ItemModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE63067283E98C10057B61B /* ItemModel.swift */; };
-		8EE63056283DF1030057B61B /* PostDetailBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EE63055283DF1030057B61B /* PostDetailBottomSheet.swift */; };
 		EB2FF8A12840D27600625EBC /* ListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = EB2FF8A02840D27600625EBC /* ListTableViewCell.xib */; };
 		EB2FF8A32840D27C00625EBC /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2FF8A22840D27C00625EBC /* ListTableViewCell.swift */; };
 		EB2FF8A52840D2C400625EBC /* PostListDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2FF8A42840D2C400625EBC /* PostListDataModel.swift */; };
@@ -117,6 +116,7 @@
 		EBB260D1283E1851001416D8 /* PostDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB260D0283E1851001416D8 /* PostDetail.swift */; };
 		EBB260D3283E186F001416D8 /* HomeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB260D2283E186F001416D8 /* HomeService.swift */; };
 		EBB260D5283E1877001416D8 /* HomeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB260D4283E1877001416D8 /* HomeRouter.swift */; };
+		EBC80DEE2845F8DE003162E5 /* NoData.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBC80DED2845F8DE003162E5 /* NoData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -233,6 +233,7 @@
 		EBB260D0283E1851001416D8 /* PostDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetail.swift; sourceTree = "<group>"; };
 		EBB260D2283E186F001416D8 /* HomeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeService.swift; sourceTree = "<group>"; };
 		EBB260D4283E1877001416D8 /* HomeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRouter.swift; sourceTree = "<group>"; };
+		EBC80DED2845F8DE003162E5 /* NoData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -562,6 +563,7 @@
 				EBB260CF283E1843001416D8 /* Home */,
 				EBB260A62838A0FC001416D8 /* Auth */,
 				EBB260A42838A0ED001416D8 /* GeneralResponse.swift */,
+				EBC80DED2845F8DE003162E5 /* NoData.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1035,6 +1037,7 @@
 				EBB2604C28323386001416D8 /* ChatVC.swift in Sources */,
 				EBB25FF92831EB2E001416D8 /* controllerFromStoryBoard.swift in Sources */,
 				EBB2602028321D1D001416D8 /* BaseVC.swift in Sources */,
+				EBC80DEE2845F8DE003162E5 /* NoData.swift in Sources */,
 				EBB260D5283E1877001416D8 /* HomeRouter.swift in Sources */,
 				EBB25FF52831E91C001416D8 /* ModuleFactory.swift in Sources */,
 				EBB25FBC28311DF4001416D8 /* UITableView+.swift in Sources */,

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Data/Network/Environment/NetworkConstants.swift
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Data/Network/Environment/NetworkConstants.swift
@@ -10,7 +10,8 @@ import Foundation
 struct URLConstants {
     
     // MARK: - Base URL
-    static let baseURL = "https://83008f6f-c9e8-4bb3-a1f8-db102f7e9b13.mock.pstmn.io"
+    static let baseURL = "http://13.125.157.62:8000"
+    static let mockingURL = "https://83008f6f-c9e8-4bb3-a1f8-db102f7e9b13.mock.pstmn.io"
 }
 
 struct NetworkEnvironment {

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Data/Network/Foundation/BaseRouter.swift
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Data/Network/Foundation/BaseRouter.swift
@@ -93,7 +93,7 @@ extension BaseRouter {
     }
     
     var header: HeaderType {
-        return HeaderType.withToken
+        return HeaderType.default
     }
     
     var multipart: MultipartFormData {
@@ -108,15 +108,4 @@ enum RequestParams {
     case query(_ query: [String : Any])
     case requestBody(_ body: [String : Any])
     case requestPlain
-}
-
-// MARK: toDictionary
-
-extension Encodable {
-    func toDictionary() -> [String: Any] {
-        guard let data = try? JSONEncoder().encode(self),
-              let jsonData = try? JSONSerialization.jsonObject(with: data),
-              let dictionaryData = jsonData as? [String: Any] else { return [:] }
-        return dictionaryData
-    }
 }

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Data/Network/Routers/HomeRouter.swift
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Data/Network/Routers/HomeRouter.swift
@@ -10,6 +10,7 @@ import Alamofire
 
 enum HomeRouter {
     case getPostDetail(postId: String)
+    case changeSellStatus(postId: String, onSale: Int)
 }
 
 extension HomeRouter: BaseRouter {
@@ -18,20 +19,29 @@ extension HomeRouter: BaseRouter {
         switch self {
         case .getPostDetail(let postId):
             return "/feed/\(postId)"
+        case .changeSellStatus(_, _):
+            return "/feed/on-sale"
         }
     }
     
     var method: HTTPMethod {
         switch self {
-        default:
-            return .get
+        case .getPostDetail(_):
+                return .get
+        case .changeSellStatus(_, _):
+                return .put
         }
     }
     
     var parameters: RequestParams {
         switch self {
-        default:
+        case .getPostDetail(_):
             return .requestPlain
+        case .changeSellStatus(let postId, let onSale):
+            let body: [String : Any] =
+            ["id": postId,
+             "onSale": onSale ]
+            return .requestBody(body)
         }
     }
 }

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Data/Network/Services/HomeService.swift
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Data/Network/Services/HomeService.swift
@@ -31,5 +31,20 @@ extension HomeService {
             }
         }
     }
+    
+    func changeSellStatus(postId: String, onSale: Int, completion: @escaping (NetworkResult<Any>) -> (Void)) {
+        AFManager.request(HomeRouter.changeSellStatus(postId: postId, onSale: onSale)).responseData { response in
+            switch response.result {
+            case .success:
+                guard let statusCode = response.response?.statusCode else { return }
+                guard let data = response.data else { return}
+                let networkResult = self.judgeStatus(by: statusCode, data, type: NoData.self, decodingMode: .message)
+                completion(networkResult)
+                
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
 }
 

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Domain/Model/Home/PostDetail.swift
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Domain/Model/Home/PostDetail.swift
@@ -9,6 +9,7 @@ import Foundation
 
 // MARK: - PostDetail
 struct PostDetail: Codable {
+    let _id: String
     let image: [String]
     let user: User
     let onSale: Int

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Domain/Model/NoData.swift
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Domain/Model/NoData.swift
@@ -1,0 +1,12 @@
+//
+//  NoData.swift
+//  DaangnMarket-iOS
+//
+//  Created by Junho Lee on 2022/05/31.
+//
+
+import Foundation
+
+struct NoData: Codable {
+    
+}

--- a/DaangnMarket-iOS/DaangnMarket-iOS/Presentation/Home/PostDetail/Junho/PostDetailVC.swift
+++ b/DaangnMarket-iOS/DaangnMarket-iOS/Presentation/Home/PostDetail/Junho/PostDetailVC.swift
@@ -22,6 +22,8 @@ final class PostDetailVC: BaseVC, Storyboarded {
         case postSection = 1
     }
     
+    private var postId: String?
+    
     private lazy var postContentCell = PostContentCVC()
     
     private lazy var detailCV: UICollectionView = {
@@ -71,7 +73,8 @@ final class PostDetailVC: BaseVC, Storyboarded {
         bind()
         setDelegate()
         setCollectionView()
-        getPostDetail(postId: "4ioqqfnas328sd")
+        
+        getPostDetail(postId: postId ?? "628d7c7ccd92160ec569ddf4")
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -96,7 +99,7 @@ final class PostDetailVC: BaseVC, Storyboarded {
     }
     
     private func fetchPostDetailData(data: PostDetail) {
-        
+        postContentCell.changeSellStatus(status: "\(data.onSale)")
     }
     
     // MARK: - UI & Layout
@@ -190,18 +193,21 @@ extension PostDetailVC: UICollectionViewDelegate {
 extension PostDetailVC: PostContentDelegate {
     func presentSellStatusActionSheet() {
         let actionSheet = UIAlertController(title: "상태 변경", message: nil, preferredStyle: .actionSheet)
-
+        
         let sellingAction = UIAlertAction(title: "판매중", style: .default) { _ in
             self.postContentCell.changeSellStatus(status: "판매중")
+            self.changeSellStatus(onSale: 0)
         }
         let reservedAction = UIAlertAction(title: "예약중", style: .default) { _ in
             self.postContentCell.changeSellStatus(status: "예약중")
+            self.changeSellStatus(onSale: 1)
         }
         let completedAction = UIAlertAction(title: "거래완료", style: .default) { _ in
             self.postContentCell.changeSellStatus(status: "거래완료")
+            self.changeSellStatus(onSale: 2)
         }
         let cancelAction = UIAlertAction(title: "닫기", style: .cancel, handler: nil)
-
+        
         actionSheet.addAction(sellingAction)
         actionSheet.addAction(reservedAction)
         actionSheet.addAction(completedAction)
@@ -225,4 +231,16 @@ extension PostDetailVC {
             }
         }
     }
+    
+    func changeSellStatus(onSale: Int) {
+        HomeService.shared.changeSellStatus(postId: self.postId ?? "628d7c7ccd92160ec569ddf4", onSale: onSale) { networkResult in
+            switch networkResult {
+            case .success(let message):
+                print(message)
+            default:
+                break;
+            }
+        }
+    }
 }
+


### PR DESCRIPTION
## 🔥*Pull requests*

⛳️ **작업한 브랜치**
- feature/#27

## 🚨참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
서버통신 예시 코드를 작성해 놓았으니 PostDetailVC에서 확인해주세요. Get과 Put에 대한 예시입니다.

### 서버 연결 작업 순서
1. `Network - Routers - HomeRouter`에서 원하는 메서드를 추가한다. 현재 Get 메서드인 게시글 상세보기와 Put 메서드인 changeSellStatus 메서드가 열거형의 두 케이스로 있을 것이다. 여기에 원하는 케이스를 추가한다. 
2. 열거형에 케이스를 추가하면 아래쪽의 extension에서 switch case 관련 오류가 뜰 것이다. 추가한 메서드에 맞게 path, paramter, method를 채워 넣어준다.
3. Router를 작성 완료했으면  Service를 만들어야한다. HomeService로 가서 뷰컨트롤러에서 직접 호출해줄 메서드를 작성한다. 이미 두가지 예시가 있으니 보고 따라해보시고, 어려운 부분 있으면 질문해주세용!
4. VC에서 Service에 작성한 메서드를 호출한다. 통신 결과로 case마다 원하는 처리를 해준다. UI 업데이트를 해줘야하면 UI 업데이트를 해주고, 화면전환을 해야하면 화면전환을 해주고 그런식...
5. 어려운게 당연하니까 질문 많이해주세여.. 글보다 말로 하는게 편하니 더 설명드리겠슴다 ㅎㅎ

- Resolved: #27
